### PR TITLE
Include `OrderType` in `ZoneParameters`

### DIFF
--- a/src/lib/ConsiderationEncoder.sol
+++ b/src/lib/ConsiderationEncoder.sol
@@ -59,6 +59,7 @@ import {
 
 import {
     Rental_validateOrder_selector,
+    Rental_OrderParameters_orderType_offset,
     Rental_ZoneParameters_orderHash_offset,
     Rental_ZoneParameters_fulfiller_offset,
     Rental_ZoneParameters_offerer_offset,
@@ -70,6 +71,7 @@ import {
     Rental_ZoneParameters_startTime_offset,
     Rental_ZoneParameters_endTime_offset,
     Rental_ZoneParameters_zoneHash_offset,
+    Rental_ZoneParameters_orderType_offset,
     Rental_ZoneParameters_base_tail_offset
 } from "./rental/ConsiderationConstants.sol";
 import {StructPointers} from "./rental/ConsiderationStructs.sol";
@@ -373,13 +375,14 @@ contract ConsiderationEncoder {
         // Get the memory pointer to the order parameters struct.
         MemoryPointer src = orderParameters.toMemoryPointer();
 
-        // Copy offerer, startTime, endTime and zoneHash to zoneParameters.
+        // Copy offerer, startTime, endTime, zoneHash, and orderType to zoneParameters.
         dstHead.offset(Rental_ZoneParameters_offerer_offset).write(src.readUint256());
         dstHead.offset(Rental_ZoneParameters_startTime_offset).write(
             src.offset(OrderParameters_startTime_offset).readUint256()
         );
         dstHead.offset(Rental_ZoneParameters_endTime_offset).write(src.offset(OrderParameters_endTime_offset).readUint256());
         dstHead.offset(Rental_ZoneParameters_zoneHash_offset).write(src.offset(OrderParameters_zoneHash_offset).readUint256());
+        dstHead.offset(Rental_ZoneParameters_orderType_offset).write(src.offset(Rental_OrderParameters_orderType_offset).readUint256());
 
         // Initialize tail offset, used to populate the offer array.
         uint256 tailOffset = Rental_ZoneParameters_base_tail_offset;

--- a/src/lib/rental/ConsiderationConstants.sol
+++ b/src/lib/rental/ConsiderationConstants.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-uint256 constant Rental_validateOrder_selector = 0x827b45fa;
+uint256 constant Rental_validateOrder_selector = 0x0064e1d4;
 
 // Zone Parameters
 uint256 constant Rental_ZoneParameters_orderHash_offset = 0x00;

--- a/src/lib/rental/ConsiderationConstants.sol
+++ b/src/lib/rental/ConsiderationConstants.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 uint256 constant Rental_validateOrder_selector = 0x827b45fa;
 
+// Zone Parameters
 uint256 constant Rental_ZoneParameters_orderHash_offset = 0x00;
 uint256 constant Rental_ZoneParameters_fulfiller_offset = 0x20;
 uint256 constant Rental_ZoneParameters_offerer_offset = 0x40;
@@ -14,4 +15,8 @@ uint256 constant Rental_ZoneParameters_orderHashes_head_offset = 0xe0;
 uint256 constant Rental_ZoneParameters_startTime_offset = 0x100;
 uint256 constant Rental_ZoneParameters_endTime_offset = 0x120;
 uint256 constant Rental_ZoneParameters_zoneHash_offset = 0x140;
-uint256 constant Rental_ZoneParameters_base_tail_offset = 0x160;
+uint256 constant Rental_ZoneParameters_orderType_offset = 0x160;
+uint256 constant Rental_ZoneParameters_base_tail_offset = 0x180;
+
+// Order Parameters
+uint256 constant Rental_OrderParameters_orderType_offset = 0x80;

--- a/src/lib/rental/ConsiderationStructs.sol
+++ b/src/lib/rental/ConsiderationStructs.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import { ItemType, OrderType } from "seaport-types/src/lib/ConsiderationEnums.sol";
+import { OrderType } from "seaport-types/src/lib/ConsiderationEnums.sol";
 
 import {
     ReceivedItem,
@@ -30,6 +30,7 @@ struct ZoneParameters {
     uint256 startTime;
     uint256 endTime;
     bytes32 zoneHash;
+    OrderType orderType;
 }
 
 library StructPointers {

--- a/test/ZoneInteraction.sol
+++ b/test/ZoneInteraction.sol
@@ -18,7 +18,7 @@ import {ZoneParameters} from "src/lib/rental/ConsiderationStructs.sol";
 
 import {Zone} from "test/helpers/Zone.sol";
 import {Utils} from "test/helpers/Utils.sol";
-
+import "forge-std/console.sol";
 contract ZoneInteraction_Test is Test, ZoneInteraction {
     address mockERC20;
     address mockERC721;

--- a/test/helpers/Zone.sol
+++ b/test/helpers/Zone.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
-import {SpentItem, ReceivedItem} from "seaport-types/src/lib/ConsiderationStructs.sol";
+import {SpentItem, ReceivedItem, OrderType} from "seaport-types/src/lib/ConsiderationStructs.sol";
 
 import {ZoneParameters} from "src/lib/rental/ConsiderationStructs.sol";
 
@@ -19,6 +19,7 @@ contract Zone {
     uint256 public startTime;
     uint256 public endTime;
     bytes32 public zoneHash;
+    OrderType public orderType;
   
     function validateOrder(ZoneParameters calldata zoneParams) external returns (bytes4 validOrderMagicValue) {
 
@@ -31,6 +32,7 @@ contract Zone {
         startTime = zoneParams.startTime;
         endTime = zoneParams.endTime;
         zoneHash = zoneParams.zoneHash;
+        orderType = zoneParams.orderType;
 
         // push all offer items
         for (uint256 i; i < zoneParams.offer.length; ++i) {


### PR DESCRIPTION
- added ability for zone to pass in `orderType` for the order when calling the zone contract